### PR TITLE
added check for nyquist in final decimation

### DIFF
--- a/array_processing.py
+++ b/array_processing.py
@@ -79,7 +79,9 @@ def process_array(array, network, T0):
 		if tr.stats['sampling_rate'] != 50:
 			tr.resample(50.0)
 		if tr.stats['sampling_rate'] == 50:
-			tr.decimate(2)
+			# Check that new nyquist is above high corner of filter
+			if float(params['FREQMAX']) < 50/4.0:
+				tr.decimate(2)
 	st.taper(max_percentage=None,max_length=params['TAPER'])
 	st.filter('bandpass',freqmin=params['FREQMIN'],freqmax=params['FREQMAX'],corners=2,zerophase=True)
 	st.trim(t1,t2+params['WINDOW_LENGTH'])


### PR DESCRIPTION
Added check for nyquist on last decimation step.  I don't think the code ever gets to this block, but I'm doing what I'm told.  Frankly, I'm not sure why you don't use resample on the stream.  Yes, its slower, but I'm not sure that the comparisons to the integer sample rates are doing anything.  The sampling rates I've seen are all floats, so everything is getting resampled to 50.0 sps anyway and none of the decimate steps are utilized.